### PR TITLE
dvipdfmx.def: use \special{pdf:pagesize ...}

### DIFF
--- a/dvipdfmx.def
+++ b/dvipdfmx.def
@@ -16,7 +16,7 @@
 %% https://github.com/latex3/graphics-def/issues
 %%
 \ProvidesFile{dvipdfmx.def}
-  [2016/07/02 v4.10 LaTeX color/graphics driver for dvipdfmx (L3/ChoF)]
+  [2016/07/07 v4.11 LaTeX color/graphics driver for dvipdfmx (L3/ChoF)]
 %
 \def\c@lor@arg#1{%
   \dimen@#1\p@
@@ -423,6 +423,9 @@
 
 % v4.10
 % Support new (no)setpagesize option of graphics and color.
+% v4.11
+% Use \special{pdf:pagesize ...} instead of \special{papersize=...}
+% to support \mag (dvipdfmx only)
 \@ifundefined{ifGin@setpagesize}
 {\expandafter\let\csname ifGin@setpagesize\expandafter\endcsname
 \csname iftrue\endcsname}
@@ -437,7 +440,7 @@
 \fi
 \ifdim\paperwidth>\z@
 \ifdim\paperheight>\z@
-\special{papersize=\the\paperwidth,\the\paperheight}%
+\special{pdf:pagesize width \the\paperwidth\space height \the\paperheight}%
 \fi
 \fi
 \endgroup}}


### PR DESCRIPTION
Hello,

We (texjporg) found that "simple" papersize specials in dvips.def/dvipdfmx.def like

``` tex
\special{papersize=\the\paperwidth,\the\paperheight}%
```

are problematic when there is a possibility of \mag effects on \dimen's (\paperwidth/\paperheight). For example, the most famous Japanese document class (jsarticle.cls) uses \mag feature, and new graphics-def brakes the page layout.

``` tex
% platex + dvips (for [dvips]); platex + dvipdfmx (for [dvipdfmx])
\documentclass[21pt]{jsarticle}
\usepackage[dvips]{graphicx} % dvips.def [2016/06/17 v3.0m] or later
%\usepackage[dvipdfmx]{graphicx} % dvipdfmx.def [2016/07/02 v4.10] or later
\begin{document}
test
\end{document}
```

To avoid this problem, dvipdfmx.def and dvips.def have to be revised:

[1] Dvipdfmx can understand `\special{pdf:pagesize ...}`, so dvipdfmx.def can use it. That is my intention for opening this pull request.

[2] Dvips can understand only `\special{papersize=...}`, so ad-hoc correction (whose effect should be localized to papersize special) is required, using the effective \mag value. For example, we might use following code for dvips.def:

``` tex
% dvips.def (around l.148)
    \ifx\stockwidth\@undefined\else
      \paperwidth\stockwidth
      \paperheight\stockheight
    \fi
% ===== Add following 6 lines =====
    \ifnum\mag=\@m\relax\else
      \divide\paperwidth by \@m
      \divide\paperheight by \@m
      \multiply\paperwidth by \mag
      \multiply\paperheight by \mag
    \fi
% ===== End =====
    \ifdim\paperwidth>\z@
      \ifdim\paperheight>\z@
        \special{papersize=\the\paperwidth,\the\paperheight}%
      \fi
    \fi
```

(there might be some cancellation of significant digits, though)

The \dimen's in `\special{papersize=...}` is always interpreted as truedimen (for historical reasons, maybe), so it would be helpful if the above two patches are accepted. Thanks.
