### PR TITLE
Support geometry with mag option (pdftex/xetex/dvipdfmx)

### DIFF
--- a/dvipdfmx.def
+++ b/dvipdfmx.def
@@ -16,7 +16,7 @@
 %% https://github.com/latex3/graphics-def/issues
 %%
 \ProvidesFile{dvipdfmx.def}
-  [2016/07/07 v4.11 LaTeX color/graphics driver for dvipdfmx (L3/ChoF)]
+  [2016/07/09 v4.12 LaTeX color/graphics driver for dvipdfmx (L3/ChoF)]
 %
 \def\c@lor@arg#1{%
   \dimen@#1\p@
@@ -426,6 +426,9 @@
 % v4.11
 % Use \special{pdf:pagesize ...} instead of \special{papersize=...}
 % to support \mag (dvipdfmx only)
+% v4.12
+% Do not set \special when geometry.sty is used, because it can
+% set papersize by itself
 \@ifundefined{ifGin@setpagesize}
 {\expandafter\let\csname ifGin@setpagesize\expandafter\endcsname
 \csname iftrue\endcsname}
@@ -433,6 +436,7 @@
 \ifGin@setpagesize
 \ifx\paperwidth\@undefined\else
 \AtBeginDocument{\AtBeginDvi{%
+\@ifpackageloaded{geometry}{}{%
 \begingroup
 \ifx\stockwidth\@undefined\else
 \paperwidth\stockwidth
@@ -443,7 +447,9 @@
 \special{pdf:pagesize width \the\paperwidth\space height \the\paperheight}%
 \fi
 \fi
-\endgroup}}
+\endgroup
+}%
+}}
 \fi
 \fi 
 

--- a/pdftex.def
+++ b/pdftex.def
@@ -268,6 +268,9 @@
 %  * typo
 % 2016/06/17 v0.6h (DPC)
 %  * guards for contributed packages and plain TeX
+% 2016/07/09 v0.6i
+%  * don't set pagesize when geometry.sty is used, because it can
+%    set pagesize by itself
 %
 % Prefix of internal commands for this file `pdftex.def':
 %   \GPT@ (Graphics bundle PdfTex driver)
@@ -452,6 +455,7 @@
 \ifGin@setpagesize
 \ifx\paperwidth\@undefined\else
 \AtBeginDocument{%
+\@ifpackageloaded{geometry}{}{%
   \ltx@IfUndefined{stockwidth}{%
   \ltx@IfUndefined{paperwidth}{%
   }{%
@@ -462,14 +466,15 @@
       \fi
     \fi
   }%
-}{%
-  \ifdim\stockwidth>0pt\relax
-    \ifdim\stockheight>0pt\relax
-      \pdfpagewidth=\stockwidth
-      \pdfpageheight=\stockheight
+  }{%
+    \ifdim\stockwidth>0pt\relax
+      \ifdim\stockheight>0pt\relax
+        \pdfpagewidth=\stockwidth
+        \pdfpageheight=\stockheight
+      \fi
     \fi
-  \fi
-}%
+  }%
+  }%
 }
 \fi
 \fi

--- a/xetex.def
+++ b/xetex.def
@@ -22,6 +22,9 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%  Version History
 %%
+%%  2016/07/09  [v4.10] don't set pagesize when geometry.sty is used,
+%%              because it can set pagesize by itself
+%%
 %%  2016/07/02  [DPC] [v4.09] support new (no)setpagesize options of
 %%              color and graphics packages.
 %%              revert pagecolor code to match dvips
@@ -118,7 +121,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % emacs-page
 \ProvidesFile{xetex.def}
-  [2016/07/02 v4.09 LaTeX color/graphics driver for XeTeX (L3/RRM/JK)]
+  [2016/07/09 v4.10 LaTeX color/graphics driver for XeTeX (L3/RRM/JK)]
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % make sure we can use " with correct catcode
@@ -690,33 +693,35 @@
 % (no)setpagesize option
 %
 \@ifundefined{ifGin@setpagesize}
-{\expandafter\let\csname ifGin@setpagesize\expandafter\endcsname
-\csname iftrue\endcsname}
-{}
+  {\expandafter\let\csname ifGin@setpagesize\expandafter\endcsname
+                    \csname iftrue\endcsname}
+  {}
 \ifGin@setpagesize
 \ifx\paperwidth\@undefined\else
 \AtBeginDocument{%
-\ltx@IfUndefined{stockwidth}{%
-\ltx@IfUndefined{paperwidth}{%
-}{%
-\ifdim\paperwidth>0pt\relax
-\ifdim\paperheight>0pt\relax
-\pdfpagewidth=\paperwidth
-\pdfpageheight=\paperheight
-\fi
-\fi
-}%
-}{%
-\ifdim\stockwidth>0pt\relax
-\ifdim\stockheight>0pt\relax
-\pdfpagewidth=\stockwidth
-\pdfpageheight=\stockheight
-\fi
-\fi
-}%
+\@ifpackageloaded{geometry}{}{%
+  \ltx@IfUndefined{stockwidth}{%
+  \ltx@IfUndefined{paperwidth}{%
+  }{%
+    \ifdim\paperwidth>0pt\relax
+      \ifdim\paperheight>0pt\relax
+        \pdfpagewidth=\paperwidth
+        \pdfpageheight=\paperheight
+      \fi
+    \fi
+  }%
+  }{%
+    \ifdim\stockwidth>0pt\relax
+      \ifdim\stockheight>0pt\relax
+        \pdfpagewidth=\stockwidth
+        \pdfpageheight=\stockheight
+      \fi
+    \fi
+  }%
+  }%
 }
 \fi
-\fi 
+\fi
 
 \endinput
 %%


### PR DESCRIPTION
As stated in #1, new pdftex.def and xetex.def breaks pagesize:

``` tex
\documentclass[a4paper]{article}
\usepackage[mag=707]{geometry}
\usepackage{graphicx}
\begin{document}
test
\end{document}
```

This should yield A5 layout, but output is wrong. I don't think it would be good that graphicx modifies papersize after geometry has set it already.

Similar for dvipdfmx.def:

``` tex
\documentclass[a4paper]{article}
\usepackage[mag=707,dvipdfm]{geometry}
\usepackage[dvipdfmx]{graphicx}
\begin{document}
test
\end{document}
```
