### PR TITLE
Fix pagecolor for pdftex and luatex / correct nopagecolor for xetex/dvipdfmx

### DIFF
--- a/dvipdfmx.def
+++ b/dvipdfmx.def
@@ -16,7 +16,7 @@
 %% https://github.com/latex3/graphics-def/issues
 %%
 \ProvidesFile{dvipdfmx.def}
-  [2017/06/24 v5.0g Graphics/color driver for dvipdfmx]
+  [2020/08/26 v5.0h Graphics/color driver for dvipdfmx]
 \def\GPT@space{ }
 \def\c@lor@arg#1{%
   \dimen@#1\p@

--- a/dvipdfmx.def
+++ b/dvipdfmx.def
@@ -83,6 +83,7 @@
         background \current@color}}
 \def\define@color@named#1#2{%
   \expandafter\let\csname col@#1\endcsname\@nnil}
+% white is special cased as "no background color" by dvipdfmx
 \def\no@page@color{\special{background gray 1}}
 \@ifundefined{Gin@decode}
   {\let\Gin@decode\@empty}

--- a/dvipdfmx.def
+++ b/dvipdfmx.def
@@ -83,7 +83,7 @@
         background \current@color}}
 \def\define@color@named#1#2{%
   \expandafter\let\csname col@#1\endcsname\@nnil}
-      \def\no@page@color{\special{background \string"newpath clip}}
+\def\no@page@color{\special{background gray 1}}
 \@ifundefined{Gin@decode}
   {\let\Gin@decode\@empty}
   {}
@@ -333,4 +333,4 @@
 \fi
 }
 \fi
-\fi 
+\fi

--- a/luatex.def
+++ b/luatex.def
@@ -126,6 +126,32 @@
 \def\no@page@color{%
   \global\GPT@pagecolorfalse
 }
+\def\@tempa{LaTeX2e}%
+\ifx\fmtname\@tempa
+  \expandafter\@firstofone
+\else
+  \expandafter\@gobble
+\fi
+ {%
+ \@ifl@t@r\fmtversion{2020/10/01}
+  {%
+    \def\set@page@color{%
+     \global\GPT@pagecolortrue
+     \global\let\current@page@color\current@color
+    }%
+    \g@addto@macro\@kernel@before@shipout@background
+     {%
+      \ifGPT@pagecolor
+        \put(-\hoffset,-\pageheight+\voffset)%
+          {%
+            \pdfextension colorstack\@pdfcolorstack push{\current@page@color}%
+            \aftergroup\reset@color
+            \rule{\pagewidth}{\pageheight}%
+          }%
+      \fi
+     }%
+  }%
+ }
 \AtBeginDocument{%
   \def\KV@Gin@bbllx{%
     \PackageError{luatex.def}{%

--- a/luatex.def
+++ b/luatex.def
@@ -72,7 +72,7 @@
   \aftergroup\reset@color}
 \def\reset@color{\pdfextension colorstack\@pdfcolorstack pop\relax}
 \newif\ifGPT@pagecolor
-\begingroup\expandafter\expandafter\expandafter\endgroup
+
 \def\set@page@color{%
   \global\GPT@pagecolortrue
   \global\let\current@page@color\current@color

--- a/luatex.def
+++ b/luatex.def
@@ -19,7 +19,7 @@
 %% https://github.com/latex3/graphics-def/issues
 %%
 \ProvidesFile{luatex.def}
-  [2020/08/09 v1.1a Graphics/color driver for luatex]
+  [2020/08/26 v1.2 Graphics/color driver for luatex]
 \def\GPT@space{ }
 \def\c@lor@arg#1{%
   \dimen@#1\p@

--- a/pdftex.def
+++ b/pdftex.def
@@ -19,7 +19,7 @@
 %% https://github.com/latex3/graphics-def/issues
 %%
 \ProvidesFile{pdftex.def}
-  [2020/08/09 v1.1a Graphics/color driver for pdftex]
+  [2020/08/26 v1.2 Graphics/color driver for pdftex]
 \def\GPT@space{ }
 \def\c@lor@arg#1{%
   \dimen@#1\p@

--- a/pdftex.def
+++ b/pdftex.def
@@ -140,6 +140,33 @@ E     \else
 \def\no@page@color{%
   \global\GPT@pagecolorfalse
 }
+
+\def\@tempa{LaTeX2e}%
+\ifx\fmtname\@tempa
+  \expandafter\@firstofone
+\else
+  \expandafter\@gobble
+\fi
+ {%
+ \@ifl@t@r\fmtversion{2020/10/01}
+  {%
+    \def\set@page@color{%
+     \global\GPT@pagecolortrue
+     \global\let\current@page@color\current@color
+    }%
+    \g@addto@macro\@kernel@before@shipout@background
+     {%
+      \ifGPT@pagecolor
+        \put(-\hoffset,-\pdfpageheight+\voffset)%
+          {%
+           \pdfcolorstack\@pdfcolorstack push{\current@page@color}%
+            \aftergroup\reset@color
+            \rule{\pdfpagewidth}{\pdfpageheight}%
+          }%
+      \fi
+     }%
+  }%
+ }
 \AtBeginDocument{%
   \def\KV@Gin@bbllx{%
     \PackageError{pdftex.def}{%

--- a/testfiles-unused/pagecolor-001.lvt
+++ b/testfiles-unused/pagecolor-001.lvt
@@ -1,0 +1,28 @@
+\input{regression-test}
+\documentclass{article}
+\usepackage
+  %[dvipdfmx]
+  {color}
+\usepackage{iftex}
+\AddToHook{shipout/background}{\put(1in,-3in){\Huge BACKGROUND TEXT}}
+\begin{document}
+\START
+\showoutput
+normal page\newpage
+\pagecolor{red}
+red page
+\newpage
+\nopagecolor
+no page color
+\newpage
+\pagecolor{green}
+new color
+\newpage
+larger mediabox
+%only pdflatex, lualatex, xelatex
+\ifluatex
+\pagewidth=2\pagewidth
+\else
+\pdfpagewidth=2\pdfpagewidth
+\fi
+\end{document}

--- a/testfiles-unused/pagecolor-plain-001.lvt
+++ b/testfiles-unused/pagecolor-plain-001.lvt
@@ -1,0 +1,5 @@
+\input miniltx
+\input color.sty
+\pagecolor{red}
+abc
+\bye

--- a/xetex.def
+++ b/xetex.def
@@ -83,7 +83,7 @@
         background \current@color}}
 \def\define@color@named#1#2{%
   \expandafter\let\csname col@#1\endcsname\@nnil}
-      \def\no@page@color{\special{background \string"newpath clip}}
+\def\no@page@color{\special{background gray 1}}
 \@ifundefined{Gin@decode}
   {\let\Gin@decode\@empty}
   {}

--- a/xetex.def
+++ b/xetex.def
@@ -83,6 +83,7 @@
         background \current@color}}
 \def\define@color@named#1#2{%
   \expandafter\let\csname col@#1\endcsname\@nnil}
+% white is special cased as "no bacground color" by dvipdfmx
 \def\no@page@color{\special{background gray 1}}
 \@ifundefined{Gin@decode}
   {\let\Gin@decode\@empty}

--- a/xetex.def
+++ b/xetex.def
@@ -16,7 +16,7 @@
 %% https://github.com/latex3/graphics-def/issues
 %%
 \ProvidesFile{xetex.def}
-  [2017/06/24 v5.0h Graphics/color driver for xetex]
+  [2020/08/26 v5.0i Graphics/color driver for xetex]
 \def\GPT@space{ }
 \def\c@lor@arg#1{%
   \dimen@#1\p@


### PR DESCRIPTION
Currently with pdflatex and lualatex the page color is visually before material added to the shipout/background hook

This pull request correct this. The new code  works only if latex-dev is detected (it requires the newest version on github, not the released one), in older latex the old code stays. 

Only pdftex.def and luatex.def has been changed. The pagecolor handling for xelatex, dvipdfmx, dvips looks imho ok. For xelatex and dvipdfmx the \nopagecolor command has been corrected (they used the dvips code which is wrong).

There are no real testfiles as it would need a new latex, but they are two files for tests in the testfiles-unused folder. 
The code has been also tested with xcolor, and I checked that it doesn't affect plaintex uses. 

(as it makes use of the new private hook it should be released only **after** the next latex-dev release)

~~~~
\documentclass{book}
\usepackage{color}

\AddToHook{shipout/background}[test]{\put(0,0){\rule[-3cm]{4cm}{3cm}}}
\begin{document}
abc
\newpage
\pagecolor{yellow}
abc
\end{document}
~~~~ 


![image](https://user-images.githubusercontent.com/4047173/91282538-c5020080-e789-11ea-808c-3acfe24cda00.png)

![image](https://user-images.githubusercontent.com/4047173/91282795-13af9a80-e78a-11ea-90c5-20e255bc584c.png)

