### PR TITLE
Only reset color once for page color

### DIFF
--- a/luatex.def
+++ b/luatex.def
@@ -148,7 +148,6 @@
           {%
             \let\current@color\current@page@color
             \set@color
-            \aftergroup\reset@color
             \rule{\pagewidth}{\pageheight}%
           }%
       \fi


### PR DESCRIPTION
\aftergroup \reset@color is already part of \set@color.

Fixes https://tex.stackexchange.com/questions/599519/lualatex-resets-text-colour-on-new-pages