### PR TITLE
pdftex.def, luatex.def: supported Adobe Illustrator format (.ai)

### DIFF
--- a/luatex.def
+++ b/luatex.def
@@ -573,8 +573,8 @@
 \fi
 \fi
 \def\Gin@extensions{%
-  .pdf,.png,.jpg,.mps,.jpeg,.jbig2,.jb2,%
-  .PDF,.PNG,.JPG,.JPEG,.JBIG2,.JB2%
+  .pdf,.ai,.png,.jpg,.mps,.jpeg,.jbig2,.jb2,%
+  .PDF,.AI,.PNG,.JPG,.JPEG,.JBIG2,.JB2%
 }
 \@namedef{Gin@rule@.jpg}#1{{jpg}{.jpg}{#1}}
 \@namedef{Gin@rule@.jpeg}#1{{jpg}{.jpeg}{#1}}
@@ -587,6 +587,8 @@
 \@namedef{Gin@rule@.mps}#1{{mps}{.mps}{#1}}
 \@namedef{Gin@rule@.pdf}#1{{pdf}{.pdf}{#1}}
 \@namedef{Gin@rule@.PDF}#1{{pdf}{.PDF}{#1}}
+\@namedef{Gin@rule@.ai}#1{{pdf}{.ai}{#1}}
+\@namedef{Gin@rule@.AI}#1{{pdf}{.AI}{#1}}
 \@namedef{Gin@rule@.eps}#1{{eps}{.eps}{#1}}
 % MPS conversion
 \def\GPT@LoadSuppPdf{%

--- a/pdftex.def
+++ b/pdftex.def
@@ -584,8 +584,8 @@ E     \else
 \fi
 \fi
 \def\Gin@extensions{%
-  .pdf,.png,.jpg,.mps,.jpeg,.jbig2,.jb2,%
-  .PDF,.PNG,.JPG,.JPEG,.JBIG2,.JB2%
+  .pdf,.ai,.png,.jpg,.mps,.jpeg,.jbig2,.jb2,%
+  .PDF,.AI,.PNG,.JPG,.JPEG,.JBIG2,.JB2%
 }
 \@namedef{Gin@rule@.jpg}#1{{jpg}{.jpg}{#1}}
 \@namedef{Gin@rule@.jpeg}#1{{jpg}{.jpeg}{#1}}
@@ -598,6 +598,8 @@ E     \else
 \@namedef{Gin@rule@.mps}#1{{mps}{.mps}{#1}}
 \@namedef{Gin@rule@.pdf}#1{{pdf}{.pdf}{#1}}
 \@namedef{Gin@rule@.PDF}#1{{pdf}{.PDF}{#1}}
+\@namedef{Gin@rule@.ai}#1{{pdf}{.ai}{#1}}
+\@namedef{Gin@rule@.AI}#1{{pdf}{.AI}{#1}}
 \@namedef{Gin@rule@.eps}#1{{eps}{.eps}{#1}}
 % MPS conversion
 \def\GPT@LoadSuppPdf{%


### PR DESCRIPTION
This PR adds support for Adobe illustrator (.ai) format inclusion to pdfTeX/LuaTeX driver. 

See 
[tex-live] Requests supporting Adobe Illustorator extension (.ai) for pdfTeX and dvipdfmx
Munehiro Yamamoto munepixyz at gmail.com
Fri Sep 20 02:04:46 CEST 2013
https://tug.org/pipermail/tex-live/2013-September/034255.html