### PR TITLE
Simplify GH Actions caching

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,26 +15,6 @@ jobs:
       # Boilerplate
       - name: Checkout repository
         uses: actions/checkout@v4
-      # GitHub Actions don't regenerate the test if the key doesn't change, so
-      # we integrate a random UUID into the key to keep them different.
-      # DO NOT CHANGE THIS
-      - name: Generate unique ID
-        id: get-id
-        run: |
-          echo -n ::set-output name=id::
-          cat /proc/sys/kernel/random/uuid
-      # Actually load the cache. Since we never reuse the key, we need restore-keys
-      # to indicate the prefix of our caches. This loads the newest cache with this
-      # prefix in the key.
-      #
-      # If we want to force regeneration of the cache, increase the number after
-      # *both* instances of "texlive-v"
-      - name: Load cache
-        uses: actions/cache@v2
-        with:
-          path: ~/texlive
-          key: texlive-v0-${{ steps.get-id.outputs.id }}
-          restore-keys: texlive-v0-
       - name: Install TeX Live
         id: texlive
         uses: zauguin/install-texlive@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,26 +13,6 @@ jobs:
       # Boilerplate
       - name: Checkout repository
         uses: actions/checkout@v4
-      # GitHub Actions don't regenerate the test if the key doesn't change, so
-      # we integrate a random UUID into the key to keep them different.
-      # DO NOT CHANGE THIS
-      - name: Generate unique ID
-        id: get-id
-        run: |
-          echo -n ::set-output name=id::
-          cat /proc/sys/kernel/random/uuid
-      # Actually load the cache. Since we never reuse the key, we need restore-keys
-      # to indicate the prefix of our caches. This loads the newest cache with this
-      # prefix in the key.
-      #
-      # If we want to force regeneration of the cache, increase the number after
-      # *both* instances of "texlive-v"
-      - name: Load cache
-        uses: actions/cache@v2
-        with:
-          path: ~/texlive
-          key: texlive-v0-${{ steps.get-id.outputs.id }}
-          restore-keys: texlive-v0-
       - name: Install TeX Live
         id: texlive
         uses: zauguin/install-texlive@v3


### PR DESCRIPTION
Action `zauguin/install-texlive` automatically caches `~/texlive` since version 2. Workflow files in this repository already uses version 3.

Similar change: latex3/latex3@1117b247 (Simplify GH Actions caching, 2022-11-29).

This also avoids deprecation warnings
- Before, 3 warnings
  https://github.com/latex3/graphics-def/actions/runs/8711930811
  ![image](https://github.com/latex3/graphics-def/assets/6376638/39d621b7-f4fb-4b4f-8bd2-dcb3b3e3c605)
- After, 0 warnings
  https://github.com/muzimuzhi/graphics-def/actions/runs/8823472706